### PR TITLE
Initialize Docker Compose for PHP-Based Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.env
+*.env.*
 
 ### VS Code ###
 .vscode/

--- a/test-server/PHP.Dockerfile
+++ b/test-server/PHP.Dockerfile
@@ -1,0 +1,4 @@
+FROM php:fpm
+
+RUN docker-php-ext-install pdo pdo_mysql
+RUN docker-php-ext-install mysqli

--- a/test-server/README.md
+++ b/test-server/README.md
@@ -1,1 +1,10 @@
-Instructions for creating the test server will be placed here.
+To prepare the server, launch with the command. You'll need the provided environment file.
+```
+docker-compose --env-file ./.env.dev up
+```
+To access the MariaDB server, access the container via the CLI
+```
+mysql --password $DB_NAME
+```
+Once created, the website can be accessed through localhost: 127.0.0.1
+Docker set-up created from: https://www.sitepoint.com/docker-php-development-environment/

--- a/test-server/app/public/index.php
+++ b/test-server/app/public/index.php
@@ -1,0 +1,16 @@
+<?php
+// PHP Test Code from https://phoenixnap.com/kb/check-php-version
+echo 'PHP version: ' . phpversion();
+foreach (get_loaded_extensions() as $i => $ext)
+{
+   echo $ext .' => '. phpversion($ext). '<br/>';
+}
+
+$pdo = new PDO('mysql:dbname=' . $_ENV["DEV_DATABASE"] . ';host=mysql', $_ENV["DEV_USER"], $_ENV["DEV_PASSWORD"], [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+$query = $pdo->query('SHOW VARIABLES like "version"');
+$row = $query->fetch();
+echo 'MySQL version:' . $row['Value'];
+
+
+?>
+<p>This means the test server is working</p>

--- a/test-server/docker-compose.yml
+++ b/test-server/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3"
+services:
+  web:
+    image: nginx:latest
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/nginx.conf
+      - ./app:/app
+  php:
+    env_file:
+      - ./.env.dev
+    build:
+      context: .
+      dockerfile: PHP.Dockerfile
+    volumes:
+      - ./app:/app
+  mysql:
+    image: mariadb:latest
+    environment:
+      MYSQL_ROOT_PASSWORD: $DEV_ROOT_PASSWORD
+      MYSQL_USER: $DEV_USER
+      MYSQL_PASSWORD: $DEV_PASSWORD
+      MYSQL_DATABASE: $DEV_DATABASE
+    volumes:
+      - mysqldata:/var/lib/mysql
+    ports:
+      - "27017:27017"
+volumes:
+  mysqldata: {}

--- a/test-server/nginx.conf
+++ b/test-server/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80 default_server;
+    root /app/public;
+    
+    index index.php index.html index.htm;
+    
+    location ~ \.php$ {
+        fastcgi_pass php:9000;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        include fastcgi_params;
+    }
+} 


### PR DESCRIPTION
The index.php is temporary, the final version shouldn't end up having
a visual component. The README.md provides simple instructions for
setting up the container services. The app folder will hold the php
scripts.